### PR TITLE
Apply tukey window tapering outside of detected transients.

### DIFF
--- a/src/EXAMPLE_EXEC/removeEQ_exec.jl
+++ b/src/EXAMPLE_EXEC/removeEQ_exec.jl
@@ -1,4 +1,4 @@
-#using Distributed
+using Distributed
 #addprocs(3)
 
 @everywhere using SeisRemoveEQ, SeisIO
@@ -8,7 +8,7 @@ using Dates, JLD2
 #==================================================#
 
 # Use SeisDownload.jl to make jld2 file.
-finame = "./dataset/3days_CInetwork_ridgecrest_fortest.jld2"
+finame = "./dataset/BPnetwork_3days_test.jld2"
 
 MAX_MEM_PER_CPU = 2.0 # [GB] maximum allocated memory for one cpu
 
@@ -29,6 +29,7 @@ stalta_threshold = 0.8 #STA/LTA threshold to detect earthquake and tremors: For 
 invert_tukey_α = 0.01 #invert_tukey window (0<α<1: 1.0 for smooth removal but causes incomplete tremors removal)
 removal_shorttimewindow = 60 * 3 # timewindow to remove EQ: removing data if this tw contains data more than threshold.
 overlap = 60; # overlap of removal window[s]
+max_wintaper_duration = 60 * 3 # maximum duration of tukey window taper: τs
 
 #---Plotting variables---#
 IsSaveFig = true # save figure to check removal
@@ -38,28 +39,29 @@ plot_span = 100 # to reduce number of plot point
 
 #---Output file info---#
 fodir       = "./dataset"
-foname      = "3days_CInetwork_ridgecrest_remEQ" # data is saved at ./dataset/$foname.jld2
+foname      = "BPnetwork_3days_test_neq" # data is saved at ./dataset/$foname.jld2
 
 #==================================================#
 
 #intended to parallelization
-InputDictionary = Dict( "MAX_MEM_PER_CPU"       => float(MAX_MEM_PER_CPU),
-                        "finame"                => finame,
-                        "IsKurtosisRemoval"     => IsKurtosisRemoval,
+InputDictionary = Dict( "MAX_MEM_PER_CPU"        => float(MAX_MEM_PER_CPU),
+                        "finame"                 => finame,
+                        "IsKurtosisRemoval"      => IsKurtosisRemoval,
                         "max_edgetaper_duration" => float(max_edgetaper_duration),
-                        "kurtosis_timewindow"   => float(kurtosis_timewindow),
-                        "kurtosis_threshold"    => float(kurtosis_threshold),
-                        "IsSTALTARemoval"       => IsSTALTARemoval,
-                        "stalta_longtimewindow" => float(stalta_longtimewindow),
-                        "stalta_threshold"      => float(stalta_threshold),
-                        "invert_tukey_α"        => float(invert_tukey_α),
+                        "kurtosis_timewindow"    => float(kurtosis_timewindow),
+                        "kurtosis_threshold"     => float(kurtosis_threshold),
+                        "max_wintaper_duration"  => float(max_wintaper_duration),
+                        "IsSTALTARemoval"        => IsSTALTARemoval,
+                        "stalta_longtimewindow"  => float(stalta_longtimewindow),
+                        "stalta_threshold"       => float(stalta_threshold),
+                        "invert_tukey_α"         => float(invert_tukey_α),
                         "removal_shorttimewindow"=> float(removal_shorttimewindow),
-                        "overlap"               => float(overlap),
-                        "plot_kurtosis_α"       => float(plot_kurtosis_α),
-                        "plot_boxheight"        => float(plot_boxheight),
-                        "plot_span"             => trunc(Int, plot_span),
-                        "fodir"                 => fodir,
-                        "foname"                => foname,
-                        "IsSaveFig"             => IsSaveFig)
+                        "overlap"                => float(overlap),
+                        "plot_kurtosis_α"        => float(plot_kurtosis_α),
+                        "plot_boxheight"         => float(plot_boxheight),
+                        "plot_span"              => trunc(Int, plot_span),
+                        "fodir"                  => fodir,
+                        "foname"                 => foname,
+                        "IsSaveFig"              => IsSaveFig)
 
 seisremoveEQ(InputDictionary)

--- a/src/get_kurtosis.jl
+++ b/src/get_kurtosis.jl
@@ -11,15 +11,15 @@ using Distributions, Statistics, Dierckx, SeisIO
 
 # Input:
     - `data::SeisData`    : SeisData from SeisIO
-    - `kurtsis_tw_sparse::Float64` : time length of span for kurtosis time window
+    - `kurtosis_tw_sparse::Float64` : time length of span for kurtosis time window
     - `timewinlength::Float64`  : time window to calculate kurtosis
     kurtosis evaluation following Baillard et al.(2013)
 """
-function get_kurtosis(data::SeisChannel, kurtsis_tw_sparse::Float64; timewinlength::Float64=60)
+function get_kurtosis(data::SeisChannel, kurtosis_tw_sparse::Float64; timewinlength::Float64=60.0)
 
     #convert window lengths from seconds to samples
     TimeWin = trunc(Int,timewinlength * data.fs)
-    data.misc["kurtosis"] = fast_kurtosis_series(data.x, TimeWin)
+    data.misc["kurtosis"] = fast_kurtosis_series(data.x, TimeWin, kurtosis_tw_sparse)
 
     return data
 
@@ -37,13 +37,13 @@ end
 
     kurtosis evaluation following Baillard et al.(2013)
 """
-function fast_kurtosis_series(v::Array{Float64, 1}, TN::Int64, kurtsis_tw_sparse::Float64)
+function fast_kurtosis_series(v::Array{Float64, 1}, TN::Int64, kurtosis_tw_sparse::Float64)
 
     kurt = zeros(length(v))
     n = length(v)
     kurt_grid = 1:n
 
-    KTWSparse = kurtsis_tw_sparse
+    KTWSparse = kurtosis_tw_sparse
 
     if n < TN error("Kurtosis time window is larger than data length. Decrease time window.") end
 

--- a/src/get_kurtosis.jl
+++ b/src/get_kurtosis.jl
@@ -5,17 +5,17 @@ export get_kurtosis
 using Distributions, Statistics, Dierckx, SeisIO
 
 """
-    get_kurtosis(data::SeisChannel,timewinlength::Float64=60)
+    get_kurtosis(data::SeisChannel,kurtsis_tw_sparse::Float64; timewinlength::Float64=60)
 
     compute kurtosis at each timewindow
 
 # Input:
     - `data::SeisData`    : SeisData from SeisIO
-    - `timewinlength::Float64`  : time window to calculate kurtosis
     - `kurtsis_tw_sparse::Float64` : time length of span for kurtosis time window
+    - `timewinlength::Float64`  : time window to calculate kurtosis
     kurtosis evaluation following Baillard et al.(2013)
 """
-function get_kurtosis(data::SeisChannel, timewinlength::Float64=60, kurtsis_tw_sparse::Float64)
+function get_kurtosis(data::SeisChannel, kurtsis_tw_sparse::Float64; timewinlength::Float64=60)
 
     #convert window lengths from seconds to samples
     TimeWin = trunc(Int,timewinlength * data.fs)

--- a/src/map_removeEQ.jl
+++ b/src/map_removeEQ.jl
@@ -29,6 +29,7 @@ function map_removeEQ(dlid, InputDict::Dict)
     stalta_longtimewindow  =InputDict["stalta_longtimewindow"]
     stalta_threshold       =InputDict["stalta_threshold"]
     invert_tukey_α         =InputDict["invert_tukey_α"]
+    max_wintaper_duration  =InputDict["max_wintaper_duration"]
     removal_shorttimewindow=InputDict["removal_shorttimewindow"]
     overlap                =InputDict["overlap"]
     plot_kurtosis_α        =InputDict["plot_kurtosis_α"]
@@ -86,7 +87,7 @@ function map_removeEQ(dlid, InputDict::Dict)
                                         float(stalta_threshold), float(overlap))
                 end
 
-                bt_3 = @elapsed S1 = Remove_eq.remove_eq(S1, S, float(invert_tukey_α), plot_kurtosis_α,
+                bt_3 = @elapsed S1 = Remove_eq.remove_eq(S1, S, float(invert_tukey_α), plot_kurtosis_α, max_wintaper_duration,
                                 plot_boxheight, trunc(Int, plot_span), fodir, tstamp, tvec, IsSaveFig)
 
 
@@ -107,7 +108,7 @@ function map_removeEQ(dlid, InputDict::Dict)
 
                     bt_2 = @elapsed S1 = Remove_eq.detect_eq_stalta(S1, float(stalta_longtimewindow), float(removal_shorttimewindow),
                                         float(stalta_threshold), float(overlap))
-                    bt_3 = @elapsed S1 = Remove_eq.remove_eq(S1, S, float(invert_tukey_α), plot_kurtosis_α,
+                    bt_3 = @elapsed S1 = Remove_eq.remove_eq(S1, S, float(invert_tukey_α), plot_kurtosis_α, max_wintaper_duration,
                                     plot_boxheight, trunc(Int, plot_span), fodir, tstamp, tvec, IsSaveFig)
 
                     #remove kurtosis for reduce size

--- a/src/map_removeEQ.jl
+++ b/src/map_removeEQ.jl
@@ -77,7 +77,7 @@ function map_removeEQ(dlid, InputDict::Dict)
             if IsKurtosisRemoval
                 # compute kurtosis and detect earthqukes
                 bt_1 = @elapsed S1 = Get_kurtosis.get_kurtosis(S1, float(kurtosis_timewindow))
-                bt_2 = @elapsed S1 = Remove_eq.detect_eq_kurtosis(S1, float(removal_shorttimewindow), float(kurtosis_threshold), float(overlap))
+                bt_2 = @elapsed S1 = Remove_eq.detect_eq_kurtosis(S1, tw=float(removal_shorttimewindow), kurtosis_threshold=float(kurtosis_threshold), overlap=float(overlap))
 
                 btsta_1 = 0
 

--- a/src/remove_eq.jl
+++ b/src/remove_eq.jl
@@ -18,7 +18,7 @@ find earthquake by kurtosis threshold
 
     kurtosis evaluation following Baillard et al.(2013)
 """
-function detect_eq_kurtosis(data::SeisChannel,tw::Float64=60.0, kurtosis_threshold::Float64=3.0, overlap::Float64=30)
+function detect_eq_kurtosis(data::SeisChannel; tw::Float64=60.0, kurtosis_threshold::Float64=3.0, overlap::Float64=30)
 
     #convert window lengths from seconds to samples
     twsize = trunc(Int, tw * data.fs)
@@ -166,7 +166,7 @@ remove earthquake by kurtosis and STA/LTA threshold
     - `data::SeisData`    : SeisData from SeisIO
 
 """
-function remove_eq(data::SeisChannel, data_origin::SeisChannel, invert_tukey_α::Float64, plot_kurtosis_α::Float64,
+function remove_eq(data::SeisChannel, data_origin::SeisChannel, invert_tukey_α::Float64, plot_kurtosis_α::Float64, max_wintaper_duration::Float64,
     plot_boxheight::Float64, plot_span::Int64, fodir::String, tstamp::String, tvec::Array{Float64,1}, IsSaveFig::Bool)
 
     eqidlist = data.misc["eqtimewindow"][:]
@@ -216,9 +216,6 @@ function remove_eq(data::SeisChannel, data_origin::SeisChannel, invert_tukey_α:
             else
                 # full taper length
                 left = t1id - max_wintaper_duration
-            end
-                # apply tukey window
-                data.x[1:t2id+max_wintaper_duration] *= invtukeywin
             end
             if length(tvec[t2id:end])<max_wintaper_duration
                 right_overflow = (max_wintaper_duration-length(tvec[t2id:end]))


### PR DESCRIPTION
I applied the tukey window such that the taper starts just outside the detected earthquakes/tremors. I also set a maximum taper length parameter, which decides tukey_window_alpha, rather than setting an alpha and accepting any tukey_window_length. This should give the largest acceptable alpha (corresponding to the smoothest invtukey window) given constraints on the taper length.